### PR TITLE
chore: keep release-please on minor bumps while pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bump-minor-pre-major": true,
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## What

Adds `"bump-minor-pre-major": true` to `release-please-config.json`.

While the project's major version is still `0`, breaking changes (`feat!` / `BREAKING CHANGE`) should bump the **minor** version (e.g. `0.3.0` → `0.4.0`) rather than jumping straight to `1.0.0`.

## Effect

The pending release PR (#352), which currently proposes `1.0.0` because of the `feat!` log/slog migration, will be recomputed to `0.4.0` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
